### PR TITLE
1.2.0 snapshot

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "net.liftmodules"
 
 liftVersion <<= liftVersion ?? "2.5-SNAPSHOT"
 
-version <<= liftVersion apply { _ + "-1.1-SNAPSHOT" }
+version <<= liftVersion apply { _ + "-1.2.0-SNAPSHOT" }
  
 scalaVersion := "2.9.2"
  

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ libraryDependencies <++= liftVersion { v =>
 } 
 
 libraryDependencies <++= scalaVersion { sv => 
-  "org.fusesource.scalate" % "scalate-core" % "1.4.1" ::
+  "org.fusesource.scalate" % "scalate-core" % "1.5.3" ::
   "javax.servlet" % "servlet-api" % "2.5" % "provided" ::
   (sv match { 
       case "2.9.2" | "2.9.1" | "2.9.1-1" => "org.scala-tools.testing" % "specs_2.9.1" % "1.6.9" % "test"

--- a/src/main/scala/net/liftmodules/scalate/ScalateView.scala
+++ b/src/main/scala/net/liftmodules/scalate/ScalateView.scala
@@ -26,7 +26,7 @@ import http._
 
 
 /**
- * A {@link LiftView} which uses a <a href="http://scalate.fusesource.org/">Scalate</a>
+ * A `LiftView` which uses a <a href="http://scalate.fusesource.org/">Scalate</a>
  * template engine to resolve a URI and render it as markup
  */
 class ScalateView(engine: LiftTemplateEngine = new LiftTemplateEngine()) extends LiftView with Logger {
@@ -34,7 +34,7 @@ class ScalateView(engine: LiftTemplateEngine = new LiftTemplateEngine()) extends
   /**
    * Registers this view with Lift's dispatcher
    */
-  def register: Unit = {
+  def register() {
     val scalateView: ScalateView = this
 
     /**
@@ -72,7 +72,7 @@ class ScalateView(engine: LiftTemplateEngine = new LiftTemplateEngine()) extends
   }
 
   protected def createUri(path: List[String], ext: String): String = path.mkString("/") +
-          (if (ext.length > 0) "." + ext else "")
+    (if (ext.length > 0) "." + ext else "")
 
   protected def canLoad(v: String): Boolean = {
     engine.canLoad(v)


### PR DESCRIPTION
- Updated Scalate version to 1.5.3.
- Previous implementation used `LiftRules.dispatch` instead of `LiftRules.viewDispatch`, effectively bypassing Lift tags and using Scalate for complete control of HTML rendering. Fixed so Lift tags work properly.
- Added support for [*.jade](http://scalate.fusesource.org/documentation/jade.html) extension.
- Due to usage change bumped version from _1.1-SNAPSHOT_ to _1.2.0-SNAPSHOT_. (Will setup an example Lift 2.5 app soon, but for testing just rename either/both _index.html_ and _templates-hidden/default.html_ to `*.scaml` or `*.ssp` or `*.jade` respectively.
