### PR TITLE
Upgrade scalate to 1.5.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "net.liftmodules"
 
 liftVersion <<= liftVersion ?? "2.5-SNAPSHOT"
 
-version <<= liftVersion apply { _ + "-1.1-SNAPSHOT" }
+version <<= liftVersion apply { _ + "-1.2-SNAPSHOT" }
  
 scalaVersion := "2.9.2"
  
@@ -22,7 +22,7 @@ libraryDependencies <++= liftVersion { v =>
 } 
 
 libraryDependencies <++= scalaVersion { sv => 
-  "org.fusesource.scalate" % "scalate-core" % "1.4.1" ::
+  "org.fusesource.scalate" % "scalate-core" % "1.5.3" ::
   "javax.servlet" % "servlet-api" % "2.5" % "provided" ::
   (sv match { 
       case "2.9.2" | "2.9.1" | "2.9.1-1" => "org.scala-tools.testing" % "specs_2.9.1" % "1.6.9" % "test"


### PR DESCRIPTION
due to incompatible version with lift 2.5, upgrading is necessary.

Exception with actual version:
Message: org.fusesource.scalate.TemplateException: scala.runtime.RichInt.until(I)Lscala/collection/immutable/Range$ByOne;
    org.fusesource.scalate.TemplateEngine.compileAndLoad(TemplateEngine.scala:775)
    ...........
Caught and thrown by:
Message: java.lang.NoSuchMethodError: scala.runtime.RichInt.until(I)Lscala/collection/immutable/Range$ByOne;
    org.fusesource.scalate.support.AbstractCodeGenerator$AbstractSourceBuilder.$less$less(AbstractCodeGenerator.scala:45)
    org.fusesource.scalate.support.AbstractCodeGenerator$AbstractSourceBuilder.generate(AbstractCodeGenerator.scala:105)  
        ...........
