### PR TITLE
Added Lifted Scaml Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This module provides integration with Scalate in two ways: Lifted Scaml (in
 2.0+), and Pure Scaml.
 
+See Also: [Sample project using Pure/Lifted Scaml](https://github.com/awkay/scalate-demo).
+
 ---
 
 **Note:** The module package changed from `net.liftweb.scalate` to `net.liftmodules.scalate` in May 2012.  Please consider this when referencing documentation written before that date.
@@ -46,8 +48,8 @@ possible to redefine the suffix that triggers the given method of processing.
 If enabled, files with this suffix are used purely as a templates for Lift. The
 rendering pipeline looks like this:
 
-    HTTP request --> There is an .lsaml file --> Lift externalTemplateResolver
-    --> Scaml to HTML/XHTML --> Lift 
+    HTTP request --> There is an .l.scaml file --> Lift externalTemplateResolver
+    --> Scaml to HTML/XHTML (cached in production) --> Lift 
 
 This means that you are using scaml to make it cleaner to write your semantic
 HTML. You can use this with both of Lift's primary template engines 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See Also: [Sample project using Pure/Lifted Scaml](https://github.com/awkay/scal
 
 In ``Boot.scala`` (You may enable either mode, or both):
 
-    LifedScaml.init // Turn on Lifted Scaml support. Templates end in .l.scaml
+    LiftedScaml.init() // Turn on Lifted Scaml support. Templates end in .l.scaml
     PureScaml.init // Turn on Pure Scaml support. Templates end in just .scaml
 
 In .l.scaml files:
@@ -64,11 +64,11 @@ time, so that:
       %b
         = java.util.Date().toString()
 
-will generate a page with the correct time on every load. However, this
-is unlikely to be what you want in 
-production mode, since that means that two rendering pipelines would be 
-running for every page load. So, in production mode, it will cache the scalate
-result for performance, and you will see the time that the page first loaded.
+will generate a page with the correct time on every load. However, this is
+unlikely to be what you want in production mode, since that means that two
+rendering pipelines would be running for every page load. So, in production
+mode, it will cache the scalate result for performance, and you will see the
+time that the page first loaded.
 
 ### The Pros:
 
@@ -82,6 +82,10 @@ result for performance, and you will see the time that the page first loaded.
 
 - You cannot embed scala code in the template that has/requires side-effects,
   since it will only run once when in production mode. 
+
+### The Truth
+
+- You can disable the production-mode caching by passing `false` to the LiftedScaml.init method 
 
 ## Pure Scalate (MVC-style)
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ This module provides integration with Scalate in two ways: Lifted Scaml (in
 
 # Synopsis
 
-In ``Boot.scala``:
+In ``Boot.scala`` (You may enable either mode, or both):
 
-    LifedScaml.init("lscaml") // Turn on Lifted Scaml support (the parameter is your desired file suffix)
-    PureScaml.init("scaml") // Turn on Pure Scaml support
+    LifedScaml.init // Turn on Lifted Scaml support. Templates end in .l.scaml
+    PureScaml.init // Turn on Pure Scaml support. Templates end in just .scaml
 
-In .lscaml files:
+In .l.scaml files:
 
     %div(class="lift:Demo1.currentTime")
       %p The time is
@@ -29,19 +29,19 @@ In .scaml files:
         %span.time 
           = java.util.Date()
 
-**The file suffix determines the processing mode**. By default, the following
+**The file suffix determines the processing mode**. The following
 suffixes have the following meanings:
 
 - .scaml - Pure Scaml (no Lift pipeline)
-- .lscaml - Lifted Scaml (``scaml (once) -> HTML -> Lift``)
+- .l.scaml - Lifted Scaml (``scaml (once) -> HTML -> Lift``)
 - .html - Regular Lift processing (template content is  HTML5/XHTML)
 
-It is possible to turn the .lscaml/.scaml modes on separately, and it is also
+It is possible to turn the .l.scaml/.scaml modes on separately, and it is also
 possible to redefine the suffix that triggers the given method of processing.
 
 # Description
 
-## Lifted Scaml (.lscaml files)
+## Lifted Scaml (.l.scaml files)
 
 If enabled, files with this suffix are used purely as a templates for Lift. The
 rendering pipeline looks like this:

--- a/README.md
+++ b/README.md
@@ -1,22 +1,116 @@
-Scalate Lift Module
-==================
+# Scalate Lift Module
 
-This module provides integration with Scalate.
+This module provides integration with Scalate in two ways: Lifted Scaml (in
+2.0+), and Pure Scaml.
 
 ---
-
-See...
-
-* [Using Scalate with Lift](http://scalate.fusesource.org/documentation/lift.html).
-
-* [Example project using Scalate](https://github.com/lift/lift/tree/master/examples/helloscalate).
 
 **Note:** The module package changed from `net.liftweb.scalate` to `net.liftmodules.scalate` in May 2012.  Please consider this when referencing documentation written before that date.
 
 ---
 
-Notes for module developers
-===========================
+# Synopsis
+
+In ``Boot.scala``:
+
+    LifedScaml.init("lscaml") // Turn on Lifted Scaml support (the parameter is your desired file suffix)
+    PureScaml.init("scaml") // Turn on Pure Scaml support
+
+In .lscaml files:
+
+    %div(class="lift:Demo1.currentTime")
+      %p The time is
+        %span.time 3:00am
+
+In .scaml files:
+
+    %div
+      %p The time is
+        %span.time 
+          = java.util.Date()
+
+**The file suffix determines the processing mode**. By default, the following
+suffixes have the following meanings:
+
+- .scaml - Pure Scaml (no Lift pipeline)
+- .lscaml - Lifted Scaml (``scaml (once) -> HTML -> Lift``)
+- .html - Regular Lift processing (template content is  HTML5/XHTML)
+
+It is possible to turn the .lscaml/.scaml modes on separately, and it is also
+possible to redefine the suffix that triggers the given method of processing.
+
+# Description
+
+## Lifted Scaml (.lscaml files)
+
+If enabled, files with this suffix are used purely as a templates for Lift. The
+rendering pipeline looks like this:
+
+    HTTP request --> There is an .lsaml file --> Lift externalTemplateResolver
+    --> Scaml to HTML/XHTML --> Lift 
+
+This means that you are using scaml to make it cleaner to write your semantic
+HTML. You can use this with both of Lift's primary template engines 
+(designer-friendly templates or XHTML), so you must ensure that your scaml 
+generates valid input to Lift.
+
+**IMPORTANT**: In development mode, scalate will run the new template every
+time, so that:
+
+    %p 
+      The time is
+      %b
+        = java.util.Date().toString()
+
+will generate a page with the correct time on every load. However, this
+is unlikely to be what you want in 
+production mode, since that means that two rendering pipelines would be 
+running for every page load. So, in production mode, it will cache the scalate
+result for performance, and you will see the time that the page first loaded.
+
+### The Pros:
+
+- You can generate clean semantic HTML with scaml
+- You can use side-effect-free Scala in your template
+- You get to use Lift for the heavy lifting
+- In production mode, it runs with normal efficiency
+- In development mode, you still get edit/save/reload behavior
+
+### The Cons:
+
+- You cannot embed scala code in the template that has/requires side-effects,
+  since it will only run once when in production mode. 
+
+## Pure Scalate (MVC-style)
+
+In this mode (which until recently was the only mode), .scaml files are
+processed by Scalate **ONLY** (Scalate generates the LiftResponse via
+early dispatch). Thus, **the entire Lift pipeline is bypassed**, and it looks
+like this:
+
+    HTTP request --> .scaml file --> Scalate --> Response
+
+There are some cases where this can be desirable, especially on pages where you
+don't need AJAX, Comet, Wiring, or any of the other Lift goodies.
+
+### The Pros:
+
+- You can use all Scalate features (including side-effect driven scala) in your
+  scaml files.
+- The rendering pipeline is shorter, and thus possibly easier on the CPU
+
+### The Cons:
+
+- You get **none** of the features that originally attracted you to Lift in 
+  the first place. No wiring, no AJAX handling, no Comet.
+
+The following example project uses this mode, and is at:
+
+* [Example project using Scalate](https://github.com/lift/lift/tree/master/examples/helloscalate).
+
+---
+
+# Notes for module developers
 
 * The [Jenkins build](https://liftmodules.ci.cloudbees.com/job/scalate/) is triggered on a push to master.
 

--- a/src/main/scala/net/liftmodules/scalate/LiftTemplateEngine.scala
+++ b/src/main/scala/net/liftmodules/scalate/LiftTemplateEngine.scala
@@ -82,6 +82,11 @@ class LiftTemplateEngine extends TemplateEngine with Loggable {
     override protected def toFile(uri: String) = {
       realFile(uri)
     }
+    
+    override def exists(uri : String) = {
+      if(uri.endsWith(".l.scaml")) false
+      else super.exists(uri)
+    }
 
     protected def toFileOrFail(uri: String): File = {
       val file = realFile(uri)
@@ -119,7 +124,6 @@ class LiftTemplateEngine extends TemplateEngine with Loggable {
         var answer: File = null
         if (path != null) {
           val file = new File(path)
-          logger.debug("file from realPath for: " + uri + " is: " + file)
           if (file.canRead) {answer = file}
         }
         answer

--- a/src/main/scala/net/liftmodules/scalate/LiftedScaml.scala
+++ b/src/main/scala/net/liftmodules/scalate/LiftedScaml.scala
@@ -1,0 +1,67 @@
+/**
+ * Lifted Scaml mode
+ * 
+ * Author: Tony Kay <tony.kay@gmail.com>
+ */
+package net.liftmodules.scalate
+
+import net.liftweb.http.LiftRules
+import java.util.Locale
+import net.liftweb.common.Full
+import net.liftweb.common.Box
+import scala.xml.NodeSeq
+import java.io.InputStream
+import net.liftweb.http.S
+import net.liftweb.common.Loggable
+import net.liftweb.common.Empty
+import java.io.StringReader
+import java.io.InputStreamReader
+import java.io.ByteArrayInputStream
+
+/**
+ * LiftedScaml template mode.
+ * 
+ * This mode allows you to write files in scaml which are then pre-processed into Lift templates.
+ * 
+ * **IMPORTANT**: In development mode, the scaml will be run every time; however, in production mode
+ * the scaml will only every be processed once, so it must be side-effect free or it will not behave
+ * as expected.
+ * 
+ * TODO: Verify proper template caching.
+ */
+object LiftedScaml {
+  /**
+   * Initialize Lifted Scaml mode. Requires an extra suffix on files as a marker.
+   * 
+   * This installs Scalate as a template resolver into the regular Lift pipeline.
+   * 
+   * Templates must be named xxx.l.scaml
+   */
+  def init = {
+    val suffix = "l.scaml"
+    val resolver = new ScamlTemplateLoader(suffix)
+    LiftRules.externalTemplateResolver.default.set(resolver.scalateTemplateLoader _)
+  }
+}
+
+class ScamlTemplateLoader(suffix : String) extends Loggable {
+  val renderer = new LiftTemplateEngine
+
+  protected def createUri(path: List[String]): String = path.mkString("/") + "." + suffix 
+
+  protected def canLoad(v: String): Boolean = v.endsWith(".l.scaml") && renderer.canLoad(v)
+
+  def canRender(path: List[String]): Boolean = canLoad(createUri(path))
+
+  def scalateTemplateLoader: PartialFunction[(Locale, List[String]), Box[NodeSeq]] = {
+    // TODO: Add locale suffix support
+    case (l, path) if (canRender(path)) => {
+      val uri: String = createUri(path)
+      logger.debug("Loading template at " + uri)
+      val rawTemplate = renderer.layout(uri)
+      val is = new ByteArrayInputStream(rawTemplate.getBytes("UTF-8"));
+      val parserFunction: InputStream => Box[NodeSeq] = S.htmlProperties.htmlParser
+      parserFunction(is)
+    }
+  }
+}

--- a/src/main/scala/net/liftmodules/scalate/LiftedScaml.scala
+++ b/src/main/scala/net/liftmodules/scalate/LiftedScaml.scala
@@ -1,6 +1,6 @@
 /**
  * Lifted Scaml mode
- * 
+ *
  * Author: Tony Kay <tony.kay@gmail.com>
  */
 package net.liftmodules.scalate
@@ -17,24 +17,25 @@ import net.liftweb.common.Empty
 import java.io.StringReader
 import java.io.InputStreamReader
 import java.io.ByteArrayInputStream
+import net.liftweb.util.NoCache
 
 /**
  * LiftedScaml template mode.
- * 
+ *
  * This mode allows you to write files in scaml which are then pre-processed into Lift templates.
- * 
+ *
  * **IMPORTANT**: In development mode, the scaml will be run every time; however, in production mode
  * the scaml will only every be processed once, so it must be side-effect free or it will not behave
  * as expected.
- * 
+ *
  * TODO: Verify proper template caching.
  */
 object LiftedScaml {
   /**
    * Initialize Lifted Scaml mode. Requires an extra suffix on files as a marker.
-   * 
+   *
    * This installs Scalate as a template resolver into the regular Lift pipeline.
-   * 
+   *
    * Templates must be named xxx.l.scaml
    */
   def init = {
@@ -44,10 +45,10 @@ object LiftedScaml {
   }
 }
 
-class ScamlTemplateLoader(suffix : String) extends Loggable {
+class ScamlTemplateLoader(suffix: String) extends Loggable {
   val renderer = new LiftTemplateEngine
 
-  protected def createUri(path: List[String]): String = path.mkString("/") + "." + suffix 
+  protected def createUri(path: List[String]): String = path.mkString("/") + "." + suffix
 
   protected def canLoad(v: String): Boolean = v.endsWith(".l.scaml") && renderer.canLoad(v)
 
@@ -55,13 +56,23 @@ class ScamlTemplateLoader(suffix : String) extends Loggable {
 
   def scalateTemplateLoader: PartialFunction[(Locale, List[String]), Box[NodeSeq]] = {
     // TODO: Add locale suffix support
-    case (l, path) if (canRender(path)) => {
+    case (locale, path) if (canRender(path)) => {
       val uri: String = createUri(path)
-      logger.debug("Loading template at " + uri)
-      val rawTemplate = renderer.layout(uri)
-      val is = new ByteArrayInputStream(rawTemplate.getBytes("UTF-8"));
-      val parserFunction: InputStream => Box[NodeSeq] = S.htmlProperties.htmlParser
-      parserFunction(is)
+      val lrCache = LiftRules.templateCache
+      val cache = if (lrCache.isDefined) lrCache.openOrThrowException("Internal Cache Error") else NoCache
+      val key = (locale, path)
+      val cachedTemplate = cache.get(key)
+      if (cachedTemplate.isDefined) {
+        cachedTemplate
+      } else {
+        logger.debug("Loading template at " + uri)
+        val rawTemplate = renderer.layout(uri)
+        val is = new ByteArrayInputStream(rawTemplate.getBytes("UTF-8"));
+        val parserFunction: InputStream => Box[NodeSeq] = S.htmlProperties.htmlParser
+        val template = parserFunction(is)
+        template.map(t => cache(key) = t)
+        template
+      }
     }
   }
 }

--- a/src/main/scala/net/liftmodules/scalate/PureScaml.scala
+++ b/src/main/scala/net/liftmodules/scalate/PureScaml.scala
@@ -1,0 +1,19 @@
+package net.liftmodules.scalate
+
+import net.liftweb.http.LiftRules
+import net.liftweb.util.NamedPF
+import net.liftweb.http.Req
+import net.liftweb.http.GetRequest
+
+/**
+ * The pure scalate engine, which technically supports .scaml or .ssp files. No Lift processing happens
+ * on these files.
+ */
+object PureScaml {
+  def init = {
+    val renderer = new ScalateView
+    LiftRules.dispatch.prepend(NamedPF("Scalate Dispatch") {
+      case Req(path, ext, GetRequest) if (renderer.canRender(path, ext)) => renderer.render(path, ext)
+    })
+  }
+}

--- a/src/main/scala/net/liftmodules/scalate/PureScaml.scala
+++ b/src/main/scala/net/liftmodules/scalate/PureScaml.scala
@@ -1,3 +1,8 @@
+/**
+ * PureScaml mode setup.
+ * 
+ * Author: Tony Kay <tony.kay@gmail.com>
+ */
 package net.liftmodules.scalate
 
 import net.liftweb.http.LiftRules

--- a/src/main/scala/net/liftmodules/scalate/ScalateView.scala
+++ b/src/main/scala/net/liftmodules/scalate/ScalateView.scala
@@ -24,7 +24,6 @@ import common._
 import util._
 import http._
 
-
 /**
  * A {@link LiftView} which uses a <a href="http://scalate.fusesource.org/">Scalate</a>
  * template engine to resolve a URI and render it as markup
@@ -34,6 +33,7 @@ class ScalateView(engine: LiftTemplateEngine = new LiftTemplateEngine()) extends
   /**
    * Registers this view with Lift's dispatcher
    */
+  @deprecated("Use PureScaml.init instead", "2013-02-10 (version 2.0)")
   def register: Unit = {
     val scalateView: ScalateView = this
 
@@ -64,10 +64,10 @@ class ScalateView(engine: LiftTemplateEngine = new LiftTemplateEngine()) extends
 
     if (ext == "") {
       canLoad(createUri(path, "scaml")) || canLoad(createUri(path, "ssp"))
-    }
+    } 
     else {
       val uri = createUri(path, ext)
-      (uri.endsWith(".ssp") || uri.endsWith(".scaml")) && canLoad(uri)
+      !uri.endsWith(".l.scaml") && (uri.endsWith(".ssp") || uri.endsWith(".scaml")) && canLoad(uri)
     }
   }
 


### PR DESCRIPTION
Hi,

I've added a "Lifted Scaml" mode to scalate which allows one to use scaml as a template preprocessor for Lift. The details are in the README.md.

I've deprecated the old style of initialization in Boot.scala. It still works if you do it the old way, but since there are two modes now, I've added something that uses the pattern of many other modules.

I have also written an updated demo project that is mentioned in the README.md.
